### PR TITLE
feat(neusis): add amunoz oppy pi and codex setup

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -5,7 +5,6 @@
     # Nixpkgs
     nixpkgs-stable.url = "github:nixos/nixpkgs/nixos-25.05";
     nixpkgs.url = "github:nixos/nixpkgs/nixos-unstable";
-    nixpkgs-master.url = "github:nixos/nixpkgs/master";
 
     # darwin inputs
     darwin = {
@@ -181,6 +180,24 @@
         in
         {
           "amunoz@moby" = lib.homeManagerConfiguration {
+            pkgs = pkgsFor.x86_64-linux;
+            extraSpecialArgs = { inherit inputs outputs; };
+            modules = [ outputs.homeModules.amunoz ];
+          };
+
+          "amunoz@oppy" = lib.homeManagerConfiguration {
+            pkgs = pkgsFor.x86_64-linux;
+            extraSpecialArgs = { inherit inputs outputs; };
+            modules = [ outputs.homeModules.amunoz ];
+          };
+
+          "amunoz@spirit" = lib.homeManagerConfiguration {
+            pkgs = pkgsFor.x86_64-linux;
+            extraSpecialArgs = { inherit inputs outputs; };
+            modules = [ outputs.homeModules.amunoz ];
+          };
+
+          "amunoz@karkinos" = lib.homeManagerConfiguration {
             pkgs = pkgsFor.x86_64-linux;
             extraSpecialArgs = { inherit inputs outputs; };
             modules = [ outputs.homeModules.amunoz ];

--- a/homes/amunoz/home.nix
+++ b/homes/amunoz/home.nix
@@ -1,6 +1,7 @@
 {
   pkgs,
   config,
+  inputs,
   username ? null,
   ...
 }:
@@ -19,7 +20,23 @@ in
     username = "${user}";
     homeDirectory = "/${home_parent}/${user}";
     stateVersion = "24.05";
-    packages = pkgs.callPackage ./packages.nix { };
+    packages = pkgs.callPackage ./packages.nix { inherit inputs; } ++ [
+      # Recover atuin sync after server-side session invalidation. Reads
+      # username/password from rbw's "atuin" entry and the BIP39 key from
+      # the "atuin key" entry, then runs `atuin login`.
+      (pkgs.writeShellApplication {
+        name = "atuin-relogin";
+        runtimeInputs = with pkgs; [ atuin rbw ];
+        text = ''
+          set -euo pipefail
+          rbw unlock
+          user=$(rbw get atuin --field username)
+          pass=$(rbw get atuin)
+          key=$(rbw get 'atuin key')
+          atuin login -u "$user" -p "$pass" -k "$key"
+        '';
+      })
+    ];
     file = import ../../modules/shared/files.nix { inherit config pkgs; };
   };
 
@@ -112,6 +129,8 @@ in
   imports = [
     ../../modules/shared/config/opencode/opencode.nix
     ../../modules/shared/config/claude/claude.nix
+    ../../modules/shared/config/codex/codex.nix
+    ../../modules/shared/config/pi/pi.nix
     ../../modules/shared/config/email/rbw.nix
   ];
 
@@ -126,6 +145,15 @@ in
       sync_address = "https://api.atuin.sh";
       search_mode = "prefix";
     };
+  };
+
+  # Ensure the agenix-decrypted key file is mounted before atuin starts. Without
+  # this ordering, atuin's load_key() can see a broken symlink, fall through to
+  # new_key(), and write a fresh random key — encrypting subsequent records
+  # under a key nobody else has. (Source of the 1Mup orphan records of 2026-04.)
+  systemd.user.services = pkgs.lib.mkIf atuin_daemon_p {
+    atuin-daemon.Unit.After = [ "agenix.service" ];
+    atuin-daemon.Unit.Requires = [ "agenix.service" ];
   };
 
   programs.fish = {

--- a/homes/amunoz/packages.nix
+++ b/homes/amunoz/packages.nix
@@ -1,8 +1,9 @@
 # Packages that only I use
-{ pkgs }:
+{ pkgs, inputs }:
 with pkgs;
 let
   shared-packages = import ../../modules/shared/packages.nix { inherit pkgs; };
+  latestPiCodingAgent = inputs.nixpkgs.legacyPackages.${pkgs.stdenv.hostPlatform.system}.pi-coding-agent;
   # zlib12 = (zlib.overrideAttrs(p: {
   #   src = let
   #     version ="1.2.13";
@@ -47,6 +48,8 @@ in
   opencode
   gemini-cli
   claude-code
+  codex
+  latestPiCodingAgent
   #openai-whisper-cpp
   #piper-tts
 

--- a/modules/shared/config/codex/AGENTS.md
+++ b/modules/shared/config/codex/AGENTS.md
@@ -1,0 +1,6 @@
+# Codex — user-wide instructions
+
+Loaded automatically into every Codex session on every machine where
+`homeModules.amunoz` is applied. Use this file for cross-project preferences
+that should follow me everywhere; per-project context belongs in the project's
+own `AGENTS.md`.

--- a/modules/shared/config/codex/codex.nix
+++ b/modules/shared/config/codex/codex.nix
@@ -1,0 +1,21 @@
+{ config, ... }:
+{
+  # Same live-repo pattern as Claude Code: keep the tracked config file as the
+  # single source of truth, but expose it at ~/.codex/config.toml via an
+  # out-of-store symlink so edits land on the repo file immediately.
+  home.file.".codex/config.toml".source = config.lib.file.mkOutOfStoreSymlink
+    "${config.home.homeDirectory}/.local/share/src/nixos-config/modules/shared/config/codex/config.toml";
+
+  # User-wide instructions loaded into every Codex session.
+  home.file.".codex/AGENTS.md".source = config.lib.file.mkOutOfStoreSymlink
+    "${config.home.homeDirectory}/.local/share/src/nixos-config/modules/shared/config/codex/AGENTS.md";
+
+  # Mirror the small set of personal/global skills that are also exposed to
+  # Claude Code.
+  home.file.".codex/skills/trip-reconcile".source = config.lib.file.mkOutOfStoreSymlink
+    "${config.home.homeDirectory}/Documents/broad/org/.claude/skills/trip-reconcile";
+
+  # Keep the Emacs bridge available to Codex as a first-class global skill.
+  home.file.".codex/skills/emacs-pair".source = config.lib.file.mkOutOfStoreSymlink
+    "${config.home.homeDirectory}/projects/emacs-pair";
+}

--- a/modules/shared/config/codex/config.toml
+++ b/modules/shared/config/codex/config.toml
@@ -1,0 +1,27 @@
+# Declarative Codex defaults.
+#
+# Mirror the low-friction setup used in Claude Code: powerful default model,
+# no approval prompts, and full filesystem access. Use `-p fast`, `-p daily`,
+# etc. when you want a different tradeoff for a single run.
+
+model = "gpt-5.5"
+approval_policy = "never"
+sandbox_mode = "danger-full-access"
+
+[shell_environment_policy]
+inherit = "all"
+
+[profiles.daily]
+model = "gpt-5.4"
+
+[profiles.fast]
+model = "gpt-5.4-mini"
+
+[profiles.agent]
+model = "gpt-5.2"
+
+[profiles.frontier]
+model = "gpt-5.5"
+
+[tui.model_availability_nux]
+"gpt-5.6-sol" = 1

--- a/modules/shared/config/pi/models.json
+++ b/modules/shared/config/pi/models.json
@@ -1,0 +1,24 @@
+{
+  "providers": {
+    "openai-codex": {
+      "models": [
+        {
+          "id": "gpt-5.6-sol",
+          "name": "GPT-5.6-Sol",
+          "reasoning": true,
+          "thinkingLevelMap": {
+            "off": null,
+            "minimal": "low",
+            "xhigh": "xhigh"
+          },
+          "input": [
+            "text",
+            "image"
+          ],
+          "contextWindow": 272000,
+          "maxTokens": 128000
+        }
+      ]
+    }
+  }
+}

--- a/modules/shared/config/pi/pi.nix
+++ b/modules/shared/config/pi/pi.nix
@@ -1,0 +1,10 @@
+{ config, ... }:
+{
+  # Keep the tracked Pi settings file as the single source of truth while
+  # exposing it at ~/.pi/agent/settings.json for live edits.
+  home.file.".pi/agent/settings.json".source = config.lib.file.mkOutOfStoreSymlink
+    "${config.home.homeDirectory}/.local/share/src/nixos-config/modules/shared/config/pi/settings.json";
+
+  home.file.".pi/agent/models.json".source = config.lib.file.mkOutOfStoreSymlink
+    "${config.home.homeDirectory}/.local/share/src/nixos-config/modules/shared/config/pi/models.json";
+}

--- a/modules/shared/config/pi/settings.json
+++ b/modules/shared/config/pi/settings.json
@@ -1,0 +1,16 @@
+{
+  "defaultProvider": "openai-codex",
+  "defaultModel": "gpt-5.6-sol",
+  "defaultThinkingLevel": "xhigh",
+  "enabledModels": [
+    "openai-codex/gpt-5.4-mini",
+    "openai-codex/gpt-5.4",
+    "openai-codex/gpt-5.5",
+    "openai/gpt-5-codex",
+    "openai-codex/gpt-5.6-sol"
+  ],
+  "packages": [
+    "git:github.com/afermg/marimo-pair"
+  ],
+  "theme": "dark"
+}


### PR DESCRIPTION
Review-only PR for the oppy/Neusis home-manager changes.

Why this PR targets a synthetic base:
- the underlying changes are already present on `main`
- opening a normal PR to `main` would show no diff
- this base branch is pinned to the pre-change state (`3ba9490`) so the net server/home-manager changes are reviewable in GitHub

What this includes:
- `amunoz@oppy` home-manager entrypoint via the shared `homeModules.amunoz` path
- `codex` home configuration and declarative config files
- `pi` home configuration and model/settings files
- `homes/amunoz/home.nix` fix to pass `inputs` into `packages.nix`
- `homes/amunoz/packages.nix` use of `pi-coding-agent`

Validation already performed:
- `home-manager build --flake .#amunoz@oppy`
- `home-manager switch -b pre-pi-codex --flake .#amunoz@oppy` on `oppy`

Known caveat on oppy after deployment:
- `pi`/`codex` auth is not migrated automatically, so models remain unavailable there until login/auth is configured.